### PR TITLE
Supporting async-only jstransformers; fixes #166

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,29 +42,25 @@ function getLayout({ file, settings }) {
  */
 
 function render({ filename, files, metadata, settings, metalsmith }) {
-  return new Promise(resolve => {
-    const file = files[filename];
-    const layout = getLayout({ file, settings });
-    const extension = layout.split('.').pop();
+  const file = files[filename];
+  const layout = getLayout({ file, settings });
+  const extension = layout.split('.').pop();
 
-    debug(`rendering ${filename} with layout ${layout}`);
+  debug(`rendering ${filename} with layout ${layout}`);
 
-    // Stringify file contents
-    let contents = file.contents.toString();
+  // Stringify file contents
+  const contents = file.contents.toString();
 
-    const transform = getTransformer(extension);
-    const locals = Object.assign({}, metadata, file, { contents });
-    const layoutPath = path.join(metalsmith.path(settings.directory), layout);
+  const transform = getTransformer(extension);
+  const locals = Object.assign({}, metadata, file, { contents });
+  const layoutPath = path.join(metalsmith.path(settings.directory), layout);
 
-    // Transform the contents
-    contents = transform.renderFile(layoutPath, settings.engineOptions, locals).body;
-
+  // Transform the contents
+  return transform.renderFileAsync(layoutPath, settings.engineOptions, locals).then(rendered => {
     // Update file with results
     // eslint-disable-next-line no-param-reassign
-    file.contents = Buffer.from(contents);
-
+    file.contents = Buffer.from(rendered.body);
     debug(`done rendering ${filename}`);
-    return resolve();
   });
 }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -24,6 +24,23 @@ describe('metalsmith-layouts', () => {
     });
   });
 
+  it('should apply a single layout to a single file with an async jstransformer', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'single-file-async');
+    const actual = path.join(base, 'build');
+    const expected = path.join(base, 'expected');
+    const metalsmith = new Metalsmith(base);
+
+    rimraf.sync(actual);
+
+    return metalsmith.use(plugin()).build(err => {
+      if (err) {
+        return done(err);
+      }
+      expect(() => equal(actual, expected)).not.toThrow();
+      return done();
+    });
+  });
+
   it('should apply a single layout to multiple files', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'multiple-files');
     const actual = path.join(base, 'build');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^0.14.3",
     "jest": "^23.5.0",
     "jstransformer-handlebars": "^1.0.0",
+    "jstransformer-qejs": "^0.2.0",
     "lint-staged": "^7.0.0",
     "metalsmith": "^2.3.0",
     "prettier": "^1.9.2",

--- a/test/fixtures/single-file-async/expected/index.html
+++ b/test/fixtures/single-file-async/expected/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <h1>The title</h1>
+
+  </body>
+</html>

--- a/test/fixtures/single-file-async/layouts/standard.ejs
+++ b/test/fixtures/single-file-async/layouts/standard.ejs
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <%- contents %>
+  </body>
+</html>

--- a/test/fixtures/single-file-async/src/index.html
+++ b/test/fixtures/single-file-async/src/index.html
@@ -1,0 +1,4 @@
+---
+layout: standard.ejs
+---
+<h1>The title</h1>


### PR DESCRIPTION
The core of this PR is to switch from calling jstransformer's `renderFile` function to instead calling `renderFileAsync`. Because of the sync fallback support in jstransformer (https://github.com/jstransformers/jstransformer/blob/69fd94c47500fe4d4c8d9f1ac2918c2a55075db0/index.js#L345), calling the async function should work for both async and sync template engines.

The only additional change in this PR is to move code unrelated to the async operations out of the scope of the promise code. 

I looked for a place to add tests to verify, but all of the test fixtures in the repository were more granular than this specific change. All current tests pass, though. 