### PR TITLE
Update dependencies and health files and fix linter problems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # For more information about the properties used in
 # this file, please see the EditorConfig documentation:
-# http://editorconfig.org/
+# https://editorconfig.org/
 
 root = true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Automatically normalize line endings for all text-based files
-# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
+# https://git-scm.com/docs/gitattributes#_end_of_line_conversion
 * text=auto
 
 # For the following file types, normalize line endings to LF on

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Before opening an issue
 
 * The issues aren't meant for support requests but for reporting bugs and feature requests. If you
-have a support request then please use: http://metalsmith-slack.herokuapp.com/ or http://stackoverflow.com/questions/tagged/metalsmith
+have a support request then please use: http://stackoverflow.com/questions/tagged/metalsmith
 
 * If you're reporting a bug, please open either a pull request with a failing test demonstrating the
 problem, or include a link to a repository with a reduced test case demonstrating the problem.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Before opening an issue
 
 * The issues aren't meant for support requests but for reporting bugs and feature requests. If you
-have a support request then please use: http://stackoverflow.com/questions/tagged/metalsmith
+have a support request then please use: https://stackoverflow.com/questions/tagged/metalsmith
 
 * If you're reporting a bug, please open either a pull request with a failing test demonstrating the
 problem, or include a link to a repository with a reduced test case demonstrating the problem.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![build status][build-badge]][build-url]
 [![coverage status][coverage-badge]][coverage-url]
-[![greenkeeper][greenkeeper-badge]][greenkeeper-url]
 
 > A metalsmith plugin for layouts
 
@@ -148,8 +147,6 @@ There are several things that might cause you to get a `no files to process` err
 
 [build-badge]: https://travis-ci.org/metalsmith/metalsmith-layouts.svg?branch=master
 [build-url]: https://travis-ci.org/metalsmith/metalsmith-layouts
-[greenkeeper-badge]: https://badges.greenkeeper.io/metalsmith/metalsmith-layouts.svg
-[greenkeeper-url]: https://greenkeeper.io
 [coverage-badge]: https://coveralls.io/repos/github/metalsmith/metalsmith-layouts/badge.svg?branch=master
 [coverage-url]: https://coveralls.io/github/metalsmith/metalsmith-layouts?branch=master
 [slack-url]: http://metalsmith-slack.herokuapp.com/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This plugin allows you to wrap your files in a template (a `layout`) and abstract repetitive html. The plugin will pass the contents of your files to the layout as the variable `contents`, and renders the result with the appropriate templating engine. It uses the file extension of your layout to infer which templating engine to use. So layouts with names ending in `.njk` will be processed as nunjucks, `.hbs` as handlebars, etc.
 
-If you want to process templating syntax *in* your files, instead of wrapping them in a template, you can use [metalsmith-in-place](https://github.com/metalsmith/metalsmith-in-place). For usage examples check out our [wiki](https://github.com/metalsmith/metalsmith-layouts/wiki). Feel free to contribute an example if anything is missing, or update the existing ones. For support questions please use [stack overflow][stackoverflow-url] or our [slack channel][slack-url]. For templating engine specific questions try the aforementioned channels, as well as the documentation for [jstransformers](https://github.com/jstransformers) and your templating engine of choice.
+If you want to process templating syntax *in* your files, instead of wrapping them in a template, you can use [metalsmith-in-place](https://github.com/metalsmith/metalsmith-in-place). For usage examples check out our [wiki](https://github.com/metalsmith/metalsmith-layouts/wiki). Feel free to contribute an example if anything is missing, or update the existing ones. For support questions please use [Stack Overflow][stackoverflow-url]. For templating engine specific questions try the aforementioned channels, as well as the documentation for [jstransformers](https://github.com/jstransformers) and your templating engine of choice.
 
 ## How does it work
 
@@ -149,5 +149,4 @@ There are several things that might cause you to get a `no files to process` err
 [build-url]: https://travis-ci.org/metalsmith/metalsmith-layouts
 [coverage-badge]: https://coveralls.io/repos/github/metalsmith/metalsmith-layouts/badge.svg?branch=master
 [coverage-url]: https://coveralls.io/github/metalsmith/metalsmith-layouts?branch=master
-[slack-url]: http://metalsmith-slack.herokuapp.com/
-[stackoverflow-url]: http://stackoverflow.com/questions/tagged/metalsmith
+[stackoverflow-url]: https://stackoverflow.com/questions/tagged/metalsmith

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ function render({ filename, files, metadata, settings, metalsmith }) {
   const contents = file.contents.toString();
 
   const transform = getTransformer(extension);
-  const locals = Object.assign({}, metadata, file, { contents });
+  const locals = { ...metadata, ...file, contents };
   const layoutPath = path.join(metalsmith.path(settings.directory), layout);
 
   // Transform the contents
@@ -105,7 +105,7 @@ module.exports = options => (files, metalsmith, done) => {
     engineOptions: {},
     suppressNoFilesError: false
   };
-  const settings = Object.assign({}, defaults, options);
+  const settings = { ...defaults, ...options };
 
   // Check whether the pattern option is valid
   if (!(typeof settings.pattern === 'string' || Array.isArray(settings.pattern))) {

--- a/package.json
+++ b/package.json
@@ -18,23 +18,6 @@
       "lib/*.js"
     ]
   },
-  "greenkeeper": {
-    "ignore": [
-      "assert-dir-equal",
-      "coveralls",
-      "eslint",
-      "eslint-config-airbnb-base",
-      "eslint-config-prettier",
-      "eslint-plugin-import",
-      "husky",
-      "jest",
-      "jstransformer-handlebars",
-      "lint-staged",
-      "metalsmith",
-      "prettier",
-      "rimraf"
-    ]
-  },
   "devDependencies": {
     "assert-dir-equal": "^1.1.0",
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coveralls": "^3.1.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.25.3",
     "husky": "^3.1.0",
     "jest": "^25.5.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "name": "metalsmith-layouts",
   "repository": "git://github.com/metalsmith/metalsmith-layouts.git",
   "version": "2.3.1",
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "precommit": "lint-staged",
     "lint:js": "eslint '**/*.js'",
@@ -20,25 +23,25 @@
   },
   "devDependencies": {
     "assert-dir-equal": "^1.1.0",
-    "coveralls": "^3.0.0",
-    "eslint": "^4.19.1",
-    "eslint-config-airbnb-base": "^13.0.0",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-import": "^2.13.0",
-    "husky": "^0.14.3",
-    "jest": "^24.7.1",
-    "jstransformer-handlebars": "^1.0.0",
+    "coveralls": "^3.1.1",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.25.3",
+    "husky": "^3.1.0",
+    "jest": "^25.5.4",
+    "jstransformer-handlebars": "^1.1.0",
     "jstransformer-qejs": "^0.2.0",
-    "lint-staged": "^7.0.0",
+    "lint-staged": "^8.2.1",
     "metalsmith": "^2.3.0",
-    "prettier": "^1.9.2",
-    "rimraf": "^2.6.2"
+    "prettier": "^1.19.1",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "debug": "^3.1.0",
-    "inputformat-to-jstransformer": "^1.2.1",
+    "debug": "^4.3.3",
+    "inputformat-to-jstransformer": "^1.4.0",
     "is-utf8": "^0.2.1",
     "jstransformer": "^1.0.0",
-    "multimatch": "^2.1.0"
+    "multimatch": "^4.0.0"
   }
 }


### PR DESCRIPTION
### .github/ISSUE_TEMPLATE.md
* Removes Slack as this doesn't appear to be running. The link was also removed from the base metalsmith repository. (https://github.com/metalsmith/metalsmith/commit/0bea2ac0db47ebeab10e9c6a45653bf6eb7ee4ea)

### README.md
* Removes Greenkeeper as this is no longer active in favor of Snyk.

### lib/index.js
* Fixed linter problems introduced after updating dependencies. ([prefer-object-spread](https://eslint.org/docs/rules/prefer-object-spread))

### package.json
* Update all dependencies to their latest versions except `multimatch` which I only updated to 5.0.0. (Latest is 6.0.0)
  * Reduces vulnerabilities from `42 moderate severity vulnerabilities` to `5 moderate severity vulnerabilities`

---

Linting and tests all pass after these changes.